### PR TITLE
[0.5.0] bring everything up-to-date

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "async-graphql-relay"
 description = "Relay support for async-graphql"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Oscar Beaumont <oscar@otbeaumont.me>"]
-edition = "2018"
+edition = "2024"
 license = "MIT"
 
 homepage = "https://github.com/oscartbeaumont/async-graphql-relay"
@@ -16,14 +16,13 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 async-graphql = "7"
-async-graphql-relay-derive = { path = "derive", version = "^0.4" }
-async-trait = "0.1.68"
-sea-orm = { version = "0.4.2", optional = true }
+async-graphql-relay-derive = { path = "derive", version = "^0.5" }
+sea-orm = { version = "1.1.0", optional = true }
 serde = { version = "1.0.163", optional = true }
-uuid = "0.8.2"
+uuid = "1.17.0"
 
 [dev-dependencies]
-tokio = { version = "1.28.1", features = ["full"] }
+tokio = { version = "1.45.0", features = ["full"] }
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ Add `async-graphql-relay` to your dependencies:
 ```toml
 [dependencies]
 # ...
-async-graphql = "2.8.5"
-async-graphql-relay= "0.3.0"
+async-graphql-relay= "0.5.0"
 ```
 ## Usage
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "async-graphql-relay-derive"
 description = "Derive macros for async-graphql-relay crate. Don't use directly!"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Oscar Beaumont <oscar@otbeaumont.me>"]
-edition = "2018"
+edition = "2024"
 license = "MIT"
 
 homepage = "https://github.com/oscartbeaumont/async-graphql-relay"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,6 +1,6 @@
 use darling::FromDeriveInput;
 use proc_macro::TokenStream;
-use syn::{parse_macro_input, Data, DeriveInput};
+use syn::{Data, DeriveInput, parse_macro_input};
 
 #[macro_use]
 extern crate quote;
@@ -52,7 +52,7 @@ pub fn derive_relay_node_object(input: TokenStream) -> TokenStream {
 /// This enum should contain all types that that exist in your GraphQL schema to work as designed in the Relay server specification.
 /// ```
 /// #[derive(Interface, RelayInterface)] // See the 'RelayInterface' derive macro
-/// #[graphql(field(name = "id", type = "NodeGlobalID"))] // The 'RelayInterface' macro generates a type called '{enum_name}GlobalID' which should be used like this to facilitate using the async_graphql_relay::RelayNodeID for globally unique ID's
+/// #[graphql(field(name = "id", ty = "NodeGlobalID"))] // The 'RelayInterface' macro generates a type called '{enum_name}GlobalID' which should be used like this to facilitate using the async_graphql_relay::RelayNodeID for globally unique ID's
 /// pub enum Node {
 ///     User(User),
 ///     Tenant(Tenant),
@@ -114,7 +114,6 @@ pub fn derive_relay_interface(input: TokenStream) -> TokenStream {
             }
         }
 
-        #[async_graphql_relay::_async_trait]
         impl async_graphql_relay::RelayNodeInterface for Node {
             async fn fetch_node(ctx: async_graphql_relay::RelayContext, relay_id: String) -> Result<Self, async_graphql::Error> {
                 if relay_id.len() < 32 {

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -2,14 +2,10 @@
 name = "async-graphql-relay-example"
 version = "0.1.0"
 authors = ["Oscar Beaumont <oscar@otbeaumont.me>"]
-edition = "2018"
+edition = "2024"
 
 [dependencies]
-async-graphql = "3.0.38"
-actix-web = "4.3.1"
-async-graphql-actix-web = "3.0.38"
-async-graphql-relay = { path = "../" }
-async-trait = "0.1.68"
-
-[patch.crates-io]
-sea-orm = { git = "https://github.com/SeaQL/sea-orm.git", branch = "model-with-generics" } # Awaiting release
+async-graphql = "7"
+actix-web = "4.11.0"
+async-graphql-actix-web = "7.0.17"
+async-graphql-relay = { path = "../", features = ["sea-orm"] }

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -2,8 +2,8 @@ use crate::tenant::Tenant;
 use crate::user::User;
 use actix_web::guard;
 use actix_web::web::Data;
-use actix_web::{web, App, HttpResponse, HttpServer, Responder};
-use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
+use actix_web::{App, HttpResponse, HttpServer, Responder, web};
+use async_graphql::http::{GraphQLPlaygroundConfig, playground_source};
 use async_graphql::{EmptyMutation, EmptySubscription, Error, Interface, Object};
 use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse};
 use async_graphql_relay::{RelayContext, RelayInterface, RelayNodeID, RelayNodeInterface};
@@ -14,7 +14,7 @@ mod user;
 pub struct QueryRoot;
 
 #[derive(Interface, RelayInterface)]
-#[graphql(field(name = "id", type = "NodeGlobalID"))] // The 'NodeGlobalID' type comes from the 'RelayInterface' macro.
+#[graphql(field(name = "id", ty = "NodeGlobalID"))] // The 'NodeGlobalID' type comes from the 'RelayInterface' macro.
 pub enum Node {
     User(User),
     Tenant(Tenant),

--- a/example/src/tenant.rs
+++ b/example/src/tenant.rs
@@ -1,6 +1,5 @@
 use async_graphql::{Error, SimpleObject};
 use async_graphql_relay::{RelayContext, RelayNode, RelayNodeID, RelayNodeObject};
-use async_trait::async_trait;
 
 use crate::Node;
 
@@ -12,7 +11,6 @@ pub struct Tenant {
     pub description: String,
 }
 
-#[async_trait]
 impl RelayNode for Tenant {
     type TNode = Node;
 

--- a/example/src/user.rs
+++ b/example/src/user.rs
@@ -1,6 +1,5 @@
 use async_graphql::{ComplexObject, Error, SimpleObject};
 use async_graphql_relay::{RelayContext, RelayNode, RelayNodeID, RelayNodeObject};
-use async_trait::async_trait;
 
 use crate::Node;
 
@@ -13,7 +12,6 @@ pub struct User {
     pub role: String,
 }
 
-#[async_trait]
 impl RelayNode for User {
     type TNode = Node;
 


### PR DESCRIPTION
This PR aims to bring the deps up to date and prepare the 0.5.0 release

1. Remove async_trait
2. upgrade async-graphql
3. upgrade sea-orm
4. bump rust edition to 2024

~~The only change I am not confident is [the ArrayType](https://github.com/chungwong/async-graphql-relay/blob/prepare_0.5/src/lib.rs#L183-L185) from sea query. [`Uuid`](https://docs.rs/sea-query/latest/sea_query/value/enum.ArrayType.html#variant.Uuid) is featured-gated behind `with-uuid` but `async-graphql-relay` didn't specifiy it.~~ It turns out `with-uuid` is a default feature https://docs.rs/crate/sea-orm/latest/features#with-uuid